### PR TITLE
Avoid manipulating strings; some comments

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -39,13 +39,13 @@ chrome.pageAction.onClicked.addListener(function(aTab) {
             break;
         case TabStatus.COMPLETE:
         	chrome.tabs.sendMessage(aTab.id, "riab-testModifiers", function(responseValue) {
-				if (!responseValue) {
-					chrome.tabs.reload();
-				} else if (responseValue.indexOf("ctrl")>-1) {
+				if (responseValue.ctrl) {
 					chrome.tabs.duplicate(aTab.id);
-				} else if (responseValue.indexOf("shift")>-1) {
+				} else if (responseValue.shift) {
 					chrome.tabs.reload({bypassCache: true});
-				}
+				} else {
+					chrome.tabs.reload();
+                }
         	});
             break;
     }

--- a/src/background.js
+++ b/src/background.js
@@ -39,7 +39,9 @@ chrome.pageAction.onClicked.addListener(function(aTab, event) {
             break;
         case TabStatus.COMPLETE:
             if(event.ctrKey) {
-                chrome.tabs.duplicate(chrome.tabs.currentTab.id);
+                chrome.tabs.duplicate(aTab.id);
+            } else if(event.shiftKey) {
+                chrome.tabs.reload({bypassCache: true});
             } else {
                 chrome.tabs.reload();
             }

--- a/src/background.js
+++ b/src/background.js
@@ -38,7 +38,11 @@ chrome.pageAction.onClicked.addListener(function(aTab, event) {
             });
             break;
         case TabStatus.COMPLETE:
-            chrome.tabs.reload();
+            if(event.ctrKey) {
+                chrome.tabs.duplicate(chrome.tabs.currentTab.id);
+            } else {
+                chrome.tabs.reload();
+            }
             break;
     }
 });

--- a/src/background.js
+++ b/src/background.js
@@ -26,7 +26,7 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
     });
 })
 
-chrome.pageAction.onClicked.addListener(function(aTab, event) {
+chrome.pageAction.onClicked.addListener(function(aTab) {
     const TabStatus = chrome.tabs.TabStatus;
 
     switch(aTab.status) {
@@ -38,13 +38,15 @@ chrome.pageAction.onClicked.addListener(function(aTab, event) {
             });
             break;
         case TabStatus.COMPLETE:
-            if(event.ctrlKey) {
-                chrome.tabs.duplicate(aTab.id);
-            } else if(event.shiftKey) {
-                chrome.tabs.reload({bypassCache: true});
-            } else {
-                chrome.tabs.reload();
-            }
+        	chrome.tabs.sendMessage(aTab.id, "riab-testModifiers", function(responseValue) {
+				if (!responseValue) {
+					chrome.tabs.reload();
+				} else if (responseValue.indexOf("ctrl")>-1) {
+					chrome.tabs.duplicate(aTab.id);
+				} else if (responseValue.indexOf("shift")>-1) {
+					chrome.tabs.reload({bypassCache: true});
+				}
+        	});
             break;
     }
 });

--- a/src/background.js
+++ b/src/background.js
@@ -38,7 +38,7 @@ chrome.pageAction.onClicked.addListener(function(aTab, event) {
             });
             break;
         case TabStatus.COMPLETE:
-            if(event.ctrKey) {
+            if(event.ctrlKey) {
                 chrome.tabs.duplicate(aTab.id);
             } else if(event.shiftKey) {
                 chrome.tabs.reload({bypassCache: true});

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -1,0 +1,36 @@
+(function(){
+  /*
+  Check and set a global guard variable.
+  If this content script is injected into the same page again,
+  it will do nothing next time.
+  */
+  if (window.modifiersSetup) {
+    return;
+  }
+  window.modifiersSetup = true;
+  var modifiersState = "";
+
+	var modifierCallback;
+	var interactionListener = function(event){
+		var responseValue = "";
+		responseValue += (event.ctrlKey || event.metaKey) ? "ctrl" : "";
+		responseValue += (event.shiftKey) ? "shift" : "";
+		responseValue += (event.altKey) ? "alt" : "";
+		modifiersState = responseValue;
+		console.log("modifiersState: " + modifiersState);
+	};
+
+	window.addEventListener("mousemove", interactionListener)
+	window.addEventListener("mouseup", interactionListener)
+	window.addEventListener("mousedown", interactionListener)
+	window.addEventListener("mouseout", interactionListener)
+	window.addEventListener("keydown", interactionListener)
+	window.addEventListener("keyup", interactionListener)
+
+	chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
+		if (message == "riab-testModifiers")
+		{
+			sendResponse(modifiersState)
+		}
+	});
+})();

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -8,16 +8,14 @@
     return;
   }
   window.modifiersSetup = true;
-  var modifiersState = "";
+  var modifiersState = {};
 
-	var modifierCallback;
 	var interactionListener = function(event){
-		var responseValue = "";
-		responseValue += (event.ctrlKey || event.metaKey) ? "ctrl" : "";
-		responseValue += (event.shiftKey) ? "shift" : "";
-		responseValue += (event.altKey) ? "alt" : "";
-		modifiersState = responseValue;
-		console.log("modifiersState: " + modifiersState);
+		modifiersState = {
+		ctrl: (event.ctrlKey || event.metaKey),
+		shift: event.shiftKey,
+		alt: event.altKey };
+		//console.log(modifiersState);
 	};
 
 	window.addEventListener("mousemove", interactionListener)

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Reload in address bar",
-  "version": "1.6",
+  "version": "1.7",
   "author": "Peder Lång Skeidsvoll",
   "homepage_url": "http://truben.no",
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Reload in address bar",
-  "version": "1.4",
+  "version": "1.6",
   "author": "Peder Lång Skeidsvoll",
   "homepage_url": "http://truben.no",
 
@@ -17,10 +17,19 @@
     "48": "icons/refresh-48.svg"
   },
 
-  "permissions": [
+   "permissions": [
     "activeTab",
     "tabs",
-    "storage"
+    "storage",
+    "<all_urls>"
+  ],
+
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": [ "/js/content.js" ],
+      "run_at": "document_start"
+    }
   ],
 
   "background": {


### PR DESCRIPTION
First of all, I don't so much appreciate the new features that it added the content script and listens for "mousemove" and other events.
I have tried to find a way to detect the modifiers without event, but it seems impossible. This may have to rely on Mozilla's decision to add an `event` to `onClicked`.

This PR avoids manipulating strings, I guess it will put a burden, but I didn't measure it.
If the "mousemove" will consume energy, I think it should provide an option to turn off by default.