### PR TITLE
Support for reloading into a new tab

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -26,7 +26,7 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
     });
 })
 
-chrome.pageAction.onClicked.addListener(function(aTab, event) {
+chrome.pageAction.onClicked.addListener(function(aTab, OnClickData) {
     const TabStatus = chrome.tabs.TabStatus;
 
     switch(aTab.status) {
@@ -38,7 +38,13 @@ chrome.pageAction.onClicked.addListener(function(aTab, event) {
             });
             break;
         case TabStatus.COMPLETE:
-            chrome.tabs.reload();
+            const isMiddleClick = OnClickData.button === 1;
+            const isCtrlClick = OnClickData.modifiers.includes('Ctrl');
+            if (isMiddleClick || isCtrlClick) {
+                chrome.tabs.duplicate(aTab.id);
+            } else {
+                chrome.tabs.reload();
+            }
             break;
     }
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Reload in address bar",
-  "version": "1.8",
+  "version": "1.9",
   "author": "Peder Lång Skeidsvoll",
   "homepage_url": "http://truben.no",
 
@@ -9,7 +9,7 @@
 
   "applications": {
     "gecko": {
-      "strict_min_version": "57.0"
+      "strict_min_version": "72.0"
     }
   },
 


### PR DESCRIPTION
[Since Firefox 72](https://developer.mozilla.org/ru/docs/Mozilla/Firefox/Releases/72), [pageAction.onClicked](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/onClicked) supports a new parameter, `OnClickData`, containing the information about the button clicked and keyboard modifiers. It finally makes it possible to reload the page into a new tab.